### PR TITLE
Tweaks to make sure the example could run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/fsm-calc/src/App.js
+++ b/fsm-calc/src/App.js
@@ -11,7 +11,7 @@ import {
 	current,
 } from './helpers'
 
-import { StateChart } from '@statecharts/xstate-viz'
+// import { StateChart } from '@statecharts/xstate-viz'
 
 export const App = () => {
 

--- a/fsm-crud/src/components/app.js
+++ b/fsm-crud/src/components/app.js
@@ -9,7 +9,7 @@ import { randomId } from '../utils/helpers'
 
 import '../components/styles.css'
 
-import { StateChart } from '@statecharts/xstate-viz'
+// import { StateChart } from '@statecharts/xstate-viz'
 
 import whyDidYouRender from '@welldone-software/why-did-you-render'
 whyDidYouRender(React)

--- a/fsm-crud/src/fsm/mainMachine.js
+++ b/fsm-crud/src/fsm/mainMachine.js
@@ -7,7 +7,9 @@ import { Enum } from 'enumify'
 import { ServiceTypes } from './services'
 import { cancelService } from './cancelService'
 
-export class MainTypes extends Enum {}
+export class MainTypes extends Enum {
+	indexOf = (str) => this.name.indexOf(str);
+}
 MainTypes.initEnum([
 	'itemSelect',
 	'itemDetails',

--- a/fsm-crud/src/fsm/services.js
+++ b/fsm-crud/src/fsm/services.js
@@ -2,7 +2,9 @@ import { randomId } from '../utils/helpers'
 import { Enum } from 'enumify'
 import { MainTypes } from '../fsm/mainMachine'
 
-export class ServiceTypes extends Enum {}
+export class ServiceTypes extends Enum {
+	indexOf = (str) => this.name.indexOf(str);
+}
 ServiceTypes.initEnum(['loadItems', 'itemDeleteConfirm', 'createItems'])
 
 export const itemService = (ctx, e) => (cb, onReceive) => {

--- a/fsm-service-1-callback/src/app.js
+++ b/fsm-service-1-callback/src/app.js
@@ -5,7 +5,7 @@ import { useMachine } from '@xstate/react'
 import CompressMachine from './machine'
 import { dump } from './helpers'
 
-import { StateChart } from '@statecharts/xstate-viz'
+// import { StateChart } from '@statecharts/xstate-viz'
 
 import './styles.css'
 

--- a/fsm-service-1-callback/src/machine.js
+++ b/fsm-service-1-callback/src/machine.js
@@ -4,7 +4,9 @@ import { updater, assign } from './xstateImmer'
 import { Enum } from 'enumify'
 import { compressionService } from './compressionService'
 
-export class Types extends Enum {}
+export class Types extends Enum {
+	indexOf = (str) => this.name.indexOf(str);
+}
 Types.initEnum(['itemSelect'])
 
 export default Machine(

--- a/fsm-service-2-submachine/src/app.js
+++ b/fsm-service-2-submachine/src/app.js
@@ -9,7 +9,7 @@ import Row from './row'
 
 import './styles.css'
 
-import { StateChart } from '@statecharts/xstate-viz'
+// import { StateChart } from '@statecharts/xstate-viz'
 
 import whyDidYouRender from '@welldone-software/why-did-you-render'
 whyDidYouRender(React)

--- a/fsm-service-2-submachine/src/machine.js
+++ b/fsm-service-2-submachine/src/machine.js
@@ -3,7 +3,9 @@ import { Machine, send } from 'xstate'
 import { updater, assign } from './xstateImmer'
 import { Enum } from 'enumify'
 
-export class Types extends Enum {}
+export class Types extends Enum {
+	indexOf = (str) => this.name.indexOf(str);
+}
 Types.initEnum(['itemSelect'])
 
 export default Machine(

--- a/fsm-service-3-actor/src/components/app.js
+++ b/fsm-service-3-actor/src/components/app.js
@@ -5,7 +5,7 @@ import Row from './row'
 
 import './styles.css'
 
-import { StateChart } from '@statecharts/xstate-viz'
+// import { StateChart } from '@statecharts/xstate-viz'
 
 import whyDidYouRender from '@welldone-software/why-did-you-render'
 whyDidYouRender(React)

--- a/fsm-service-3-actor/src/fsm/compressionService.js
+++ b/fsm-service-3-actor/src/fsm/compressionService.js
@@ -2,7 +2,9 @@ import { random } from '../utils/helpers'
 import { WorkerTypes } from './workerMachine'
 import { Enum } from 'enumify'
 
-export class CompServiceTypes extends Enum {}
+export class CompServiceTypes extends Enum {
+	indexOf = (str) => this.name.indexOf(str);
+}
 CompServiceTypes.initEnum([
 	'pauseSong',
 	'cancelSong',

--- a/fsm-service-3-actor/src/fsm/mainMachine.js
+++ b/fsm-service-3-actor/src/fsm/mainMachine.js
@@ -5,7 +5,9 @@ import * as actions from './mainActions'
 // import * as guards from './guards'
 import { Enum } from 'enumify'
 
-export class MainTypes extends Enum {}
+export class MainTypes extends Enum {
+	indexOf = (str) => this.name.indexOf(str);
+}
 MainTypes.initEnum([
 	'addFile',
 	'updateJob',

--- a/fsm-service-3-actor/src/fsm/services.js
+++ b/fsm-service-3-actor/src/fsm/services.js
@@ -2,7 +2,9 @@ import { uuid } from '../utils/helpers'
 import { Enum } from 'enumify'
 import { Types } from '../fsm/machine'
 
-export class ServiceTypes extends Enum {}
+export class ServiceTypes extends Enum {
+	indexOf = (str) => this.name.indexOf(str);
+}
 ServiceTypes.initEnum([
 	'loadItems',
 	'itemDeleteConfirm',

--- a/fsm-service-3-actor/src/fsm/workerMachine.js
+++ b/fsm-service-3-actor/src/fsm/workerMachine.js
@@ -4,7 +4,9 @@ import * as actions from '../fsm/workerActions'
 import { compressionService } from '../fsm/compressionService'
 import { Enum } from 'enumify'
 
-export class WorkerTypes extends Enum {}
+export class WorkerTypes extends Enum {
+	indexOf = (str) => this.name.indexOf(str);
+}
 WorkerTypes.initEnum([
 	'startJob',
 	'workerProgress',

--- a/fsm-word/src/App.js
+++ b/fsm-word/src/App.js
@@ -8,7 +8,7 @@ import './styles.css'
 import { isNumber, isOperator, current, dump } from './helpers'
 import classNames from 'classnames'
 
-import { StateChart } from '@statecharts/xstate-viz'
+// import { StateChart } from '@statecharts/xstate-viz'
 
 function insertMetachars(oMsgInput, sStartTag, sEndTag) {
 	var bDouble = arguments.length > 1,


### PR DESCRIPTION
Two changes:

1. Looks like XState changed the way they compare Event Type in the `Interpreter.js`, it will now use `indexOf()` to check if an Event Type is match, hence if we use a enumified Event Type here, it won't work, however, we could add a `indexOf()` function in the enumified event type to adapt the new behavior.

2. Added `.gitignore` to ignore `node_modules` and commented out `@statecharts/xstate-viz` dependency code since it's not in the `package.json`.